### PR TITLE
Tokens temporary workaround

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,15 @@ GO_LINKER_FLAGS=-ldflags="-s -w -X main.version=$(VERSION)"
 
 all: test-unit build
 
+# this make target is for testing purposes, run it and then run lms, it will be using local built janus
+build-lms:
+	docker build -t janus-gateway .
+	docker tag janus-gateway krelms/janus-gateway:latest
+
+# and this is cleans local built image, on next lms startup dockerhub image will be downloaded
+clean-lms:
+	docker rmi krelms/janus-gateway:latest
+
 build:
 	@echo "$(OK_COLOR)==> Building default binary... $(NO_COLOR)"
 	@CGO_ENABLED=0 go build -mod=vendor ${GO_LINKER_FLAGS} -o "dist/janus"

--- a/pkg/models/rbac.go
+++ b/pkg/models/rbac.go
@@ -1,11 +1,17 @@
 package models
 
-import "sync"
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+	"time"
 
-type RoleManager struct {
-	Roles map[string]*Role
-	sync.Mutex
-}
+	"github.com/hellofresh/janus/pkg/config"
+)
 
 type Role struct {
 	ID       uint64 `json:"id"`
@@ -19,4 +25,50 @@ type Feature struct {
 	Description string `json:"description"`
 	Path        string `json:"path"`
 	Method      string `json:"method"`
+}
+
+type RoleManager struct {
+	Roles map[string]*Role
+	Conf  *config.Config
+	sync.Mutex
+}
+
+func (rm *RoleManager) FetchRoles() error {
+	url := fmt.Sprintf("%s/%s/roles", rm.Conf.RbacURL, rm.Conf.ApiVersion)
+
+	http.DefaultClient.Timeout = 5 * time.Second
+	resp, err := http.DefaultClient.Get(url)
+	if err != nil {
+		var netErr net.Error
+		if errors.As(err, &netErr) && netErr.Timeout() {
+			return ErrTimeout
+		}
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	rolesArr := []*Role{}
+	rolesMap := map[string]*Role{}
+
+	err = json.Unmarshal(body, &rolesArr)
+	if err != nil {
+		return err
+	}
+
+	for _, role := range rolesArr {
+		rolesMap[role.Name] = role
+	}
+
+	rm.Lock()
+	defer rm.Unlock()
+
+	rm.Roles = rolesMap
+
+	return nil
 }

--- a/pkg/models/token.go
+++ b/pkg/models/token.go
@@ -1,18 +1,71 @@
 package models
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
 	"sync"
 	"time"
+
+	"github.com/hellofresh/janus/pkg/config"
 )
 
-type TokenManager struct {
-	Tokens map[string]*JWTToken
-	sync.RWMutex
-}
+var (
+	ErrTimeout = errors.New("timed out")
+)
 
 type JWTToken struct {
 	ID             uint64    `json:"id"`
 	UserID         uint64    `json:"user_id"`
 	Token          string    `json:"token"`
 	ExpirationDate time.Time `json:"expiration_date"`
+}
+
+type TokenManager struct {
+	Tokens map[string]*JWTToken
+	Conf   *config.Config
+	sync.RWMutex
+}
+
+func (tm *TokenManager) FetchTokens() error {
+	url := fmt.Sprintf("%s/%s/tokens", tm.Conf.UserManagementURL, tm.Conf.ApiVersion)
+
+	http.DefaultClient.Timeout = 3 * time.Second
+	resp, err := http.DefaultClient.Get(url)
+	if err != nil {
+		var netErr net.Error
+		if errors.As(err, &netErr) && netErr.Timeout() {
+			return ErrTimeout
+		}
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	tokensArr := []*JWTToken{}
+	tokensMap := map[string]*JWTToken{}
+
+	err = json.Unmarshal(body, &tokensArr)
+	if err != nil {
+		return err
+	}
+
+	for _, token := range tokensArr {
+		tokensMap[token.Token] = token
+	}
+
+	tm.Lock()
+	defer tm.Unlock()
+
+	tm.Tokens = tokensMap
+
+	return nil
 }

--- a/pkg/plugin/authorization/errors.go
+++ b/pkg/plugin/authorization/errors.go
@@ -1,7 +1,9 @@
 package authorization
 
-import "fmt"
+import (
+	"github.com/pkg/errors"
+)
 
 var (
-	ErrTimeout = fmt.Errorf("timed out")
+	ErrTokenInvalid = errors.New("invalid token")
 )

--- a/pkg/plugin/authorization/middleware.go
+++ b/pkg/plugin/authorization/middleware.go
@@ -45,7 +45,17 @@ func TokenChecker(tokens map[string]*models.JWTToken, userToken string) error {
 		return nil
 	}
 
-	return fmt.Errorf("invalid token")
+	err := tokenManager.FetchTokens()
+	if err != nil {
+		return err
+	}
+
+	// TODO: Remove this workaround after adding sync request to Janus when token is added
+	if _, exists := tokens[userToken]; exists {
+		return nil
+	}
+
+	return ErrTokenInvalid
 }
 
 func NewRoleCheckerMiddleware() func(http.Handler) http.Handler {

--- a/pkg/plugin/authorization/roles.go
+++ b/pkg/plugin/authorization/roles.go
@@ -1,57 +1,8 @@
 package authorization
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
-	"net"
-	"net/http"
-	"time"
-
-	"github.com/hellofresh/janus/pkg/config"
 	"github.com/hellofresh/janus/pkg/models"
 )
-
-func FetchInitialRoles(conf *config.Config, roleManager *models.RoleManager) error {
-	url := fmt.Sprintf("%s/%s/roles", conf.RbacURL, conf.ApiVersion)
-
-	http.DefaultClient.Timeout = 5 * time.Second
-	resp, err := http.DefaultClient.Get(url)
-	if err != nil {
-		var netErr net.Error
-		if errors.As(err, &netErr) && netErr.Timeout() {
-			return ErrTimeout
-		}
-		return err
-	}
-
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-
-	rolesArr := []*models.Role{}
-	rolesMap := map[string]*models.Role{}
-
-	err = json.Unmarshal(body, &rolesArr)
-	if err != nil {
-		return err
-	}
-
-	for _, role := range rolesArr {
-		rolesMap[role.Name] = role
-	}
-
-	roleManager.Lock()
-	defer roleManager.Unlock()
-
-	roleManager.Roles = rolesMap
-
-	return nil
-}
 
 func UpsertRole(role *models.Role, roleManager *models.RoleManager) error {
 	roleManager.Lock()

--- a/pkg/plugin/authorization/setup.go
+++ b/pkg/plugin/authorization/setup.go
@@ -56,15 +56,15 @@ func onStartup(event interface{}) error {
 		return err
 	}
 
-	tokenManager = &models.TokenManager{Tokens: map[string]*models.JWTToken{}}
-	roleManager = &models.RoleManager{Roles: map[string]*models.Role{}}
+	tokenManager = &models.TokenManager{Tokens: map[string]*models.JWTToken{}, Conf: &conf}
+	roleManager = &models.RoleManager{Roles: map[string]*models.Role{}, Conf: &conf}
 
-	err = FetchInitialTokens(&conf, tokenManager)
-	if err != nil && !errors.Is(err, ErrTimeout) {
+	err = tokenManager.FetchTokens()
+	if err != nil && !errors.Is(err, models.ErrTimeout) {
 		return err
 	}
-	err = FetchInitialRoles(&conf, roleManager)
-	if err != nil && !errors.Is(err, ErrTimeout) {
+	err = roleManager.FetchRoles()
+	if err != nil && !errors.Is(err, models.ErrTimeout) {
 		return err
 	}
 

--- a/pkg/plugin/authorization/tokens.go
+++ b/pkg/plugin/authorization/tokens.go
@@ -1,57 +1,8 @@
 package authorization
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
-	"net"
-	"net/http"
-	"time"
-
-	"github.com/hellofresh/janus/pkg/config"
 	"github.com/hellofresh/janus/pkg/models"
 )
-
-func FetchInitialTokens(conf *config.Config, tokenManager *models.TokenManager) error {
-	url := fmt.Sprintf("%s/%s/tokens", conf.UserManagementURL, conf.ApiVersion)
-
-	http.DefaultClient.Timeout = 3 * time.Second
-	resp, err := http.DefaultClient.Get(url)
-	if err != nil {
-		var netErr net.Error
-		if errors.As(err, &netErr) && netErr.Timeout() {
-			return ErrTimeout
-		}
-		return err
-	}
-
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-
-	tokensArr := []*models.JWTToken{}
-	tokensMap := map[string]*models.JWTToken{}
-
-	err = json.Unmarshal(body, &tokensArr)
-	if err != nil {
-		return err
-	}
-
-	for _, token := range tokensArr {
-		tokensMap[token.Token] = token
-	}
-
-	tokenManager.Lock()
-	defer tokenManager.Unlock()
-
-	tokenManager.Tokens = tokensMap
-
-	return nil
-}
 
 func UpsertToken(token *models.JWTToken, tokenManager *models.TokenManager) error {
 	tokenManager.Lock()


### PR DESCRIPTION
In this PR, I implemented a temporary fix to an existing problem of login.

Before: after login on frontend, need to set timeouts (500ms) to wait token are delivered to janus gateway
Now: after login on frontend we send requests immediately, if janus don't have token in cache, it will fetch tokens once.

That's its need to be removed after we implement requesting from user-management to janus on token creation (login), but for now it will serve to show the demo as smoothly as possible