### PR TITLE
added retries to roles fetch

### DIFF
--- a/pkg/plugin/authorization/roles.go
+++ b/pkg/plugin/authorization/roles.go
@@ -37,6 +37,20 @@ func NewRoleManager(conf *config.Config) *RoleManager {
 	}
 }
 
+func (rm *RoleManager) FetchRolesWithRetry(retryAttempts int, retryTimeout time.Duration) error {
+	for i := 0; i < retryAttempts; i++ {
+		err := rm.FetchRoles()
+		if err != nil || len(rm.Roles) == 0 {
+			t := time.NewTimer(retryTimeout)
+			<-t.C
+			continue
+		}
+		return nil
+	}
+
+	return fmt.Errorf("unable to fetch roles after %d attempts", retryAttempts)
+}
+
 func (rm *RoleManager) FetchRoles() error {
 	url := fmt.Sprintf("%s/%s/roles", rm.Conf.RbacURL, rm.Conf.ApiVersion)
 

--- a/pkg/plugin/authorization/setup.go
+++ b/pkg/plugin/authorization/setup.go
@@ -1,6 +1,8 @@
 package authorization
 
 import (
+	"time"
+
 	"github.com/hellofresh/janus/pkg/config"
 	"github.com/hellofresh/janus/pkg/plugin"
 	"github.com/hellofresh/janus/pkg/proxy"
@@ -15,6 +17,9 @@ const (
 	endpointTypeField = "endpoint_type"
 	loginType         = "login"
 	logoutType        = "logout"
+
+	retryAttempts = 5
+	retryTimeout  = 3 * time.Second
 )
 
 func init() {
@@ -44,7 +49,7 @@ func onStartup(event interface{}) error {
 	if err != nil {
 		return err
 	}
-	err = rm.FetchRoles()
+	err = rm.FetchRolesWithRetry(retryAttempts, retryTimeout)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
On server, janus-gateway is fully setups before rbacgen generates roles in rbac, doesn't fetch them, and to work properply need to be restarted manually. This PR fixes this issue.